### PR TITLE
Add support for sasl

### DIFF
--- a/src/Consumer.js
+++ b/src/Consumer.js
@@ -15,7 +15,8 @@ class Consumer {
 
     const kafka = new Kafka({
       clientId: this.config.clientId,
-      brokers: this.config.address
+      brokers: this.config.address,
+      sasl: this.config.sasl
     });
 
     this.consumer = kafka.consumer({ groupId: this.config.groupId });

--- a/src/Producer.js
+++ b/src/Producer.js
@@ -4,10 +4,11 @@ class Producer {
   constructor(Logger, config) {
     this.Logger = Logger;
     this.config = config;
-
+    
     const kafka = new Kafka({
       clientId: this.config.clientId,
       brokers: this.config.address,
+      sasl: this.config.sasl
     });
 
     this.producer = kafka.producer();


### PR DESCRIPTION
Added support for [`sasl`](https://kafka.js.org/docs/configuration#a-name-sasl-a-sasl) in Kafka initialization. 

To use this, the `sasl` object needs to be added to `config/kafka.js`